### PR TITLE
Fix exceptions in TorpedoStore

### DIFF
--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -30,7 +30,7 @@ public class TorpedoStore {
 
   public boolean fire(int numberOfTorpedos){
     if(numberOfTorpedos < 1 || numberOfTorpedos > this.torpedoCount){
-      new IllegalArgumentException("numberOfTorpedos");
+      throw new IllegalArgumentException("numberOfTorpedos");
     }
 
     boolean success = false;

--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -41,7 +41,7 @@ public class TorpedoStore {
 
     if (r >= FAILURE_RATE) {
       // successful firing
-      this.torpedoCount =- numberOfTorpedos;
+      this.torpedoCount -= numberOfTorpedos;
       success = true;
     } else {
       // simulated failure

--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -41,7 +41,7 @@ public class TorpedoStore {
 
     if (r >= FAILURE_RATE) {
       // successful firing
-      this.torpedoCount -= numberOfTorpedos;
+      this.torpedoCount -= numberOfTorpedos; // Decrement torpedo count by the number of torpedos fired
       success = true;
     } else {
       // simulated failure

--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -27,7 +27,7 @@ public class TorpedoStore {
       }
     }
   }
-
+  private Random generator = new Random();
   public boolean fire(int numberOfTorpedos){
     if(numberOfTorpedos < 1 || numberOfTorpedos > this.torpedoCount){
       throw new IllegalArgumentException("numberOfTorpedos");
@@ -36,7 +36,7 @@ public class TorpedoStore {
     boolean success = false;
 
     // simulate random overheating of the launcher bay which prevents firing
-    Random generator = new Random();
+    
     double r = generator.nextDouble();
 
     if (r >= FAILURE_RATE) {


### PR DESCRIPTION
Kijavított hibák:
1.IllegalArgumentException dobás: A fire metódus most már dobja az IllegalArgumentException kivételt, ha érvénytelen a bemenet.

2.Random objektum újrahasználata: A Random objektumot a TorpedoStore osztály szintjén definiáltuk és újrahasználjuk.

3.operandus hiba: A torpedók számának csökkentése helyesen működik.